### PR TITLE
feat(Docker): Support overriding exposed database port numbmer

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -37,7 +37,7 @@ services:
   database:
     ports:
       - target: 5432
-        published: 5432
+        published: ${DB_PORT:-5432}
         protocol: tcp
 ###< doctrine/doctrine-bundle ###
 


### PR DESCRIPTION
This adds support to specify the DB_PORT env var in order to be able to override the exposed database service port number.